### PR TITLE
Fix mime, so that it can be used by vex with V 0.1.23 68e1d8e .

### DIFF
--- a/list.v
+++ b/list.v
@@ -1,9 +1,8 @@
 module mime
 
-type MimeType mime.MimeType
 
 fn load_data() map[string]MimeType {
-    mut data := map[string]MimeType{}
+    mut data := map[string]MimeType
     data['application/1d-interleaved-parityfec'] = MimeType{'iana',[]string,false,''}
     data['application/3gpdash-qoe-report+xml'] = MimeType{'iana',[]string,true,''}
     data['application/3gpp-ims+xml'] = MimeType{'iana',[]string,true,''}

--- a/mime.v
+++ b/mime.v
@@ -2,10 +2,6 @@ module mime
 
 import filepath
 
-struct Db {
-pub:
-    db map[string]MimeType
-}
 
 pub struct MimeType {
 pub:
@@ -13,6 +9,11 @@ pub:
     extensions []string
     compressible bool [skip]
     charset string [skip]
+}
+
+struct Db {
+pub:
+    db map[string]MimeType
 }
 
 fn is_mime(text string) bool {


### PR DESCRIPTION
This makes mime less complicated and importable by using its fully qualified name, 
i.e. now vex (and other modules) can do
 `import nedpals.mime`